### PR TITLE
selinux: whitelist f2fs

### DIFF
--- a/security/selinux/hooks.c
+++ b/security/selinux/hooks.c
@@ -421,6 +421,10 @@ static int sb_finish_set_opts(struct super_block *sb)
 	if (strncmp(sb->s_type->name, "sysfs", sizeof("sysfs")) == 0)
 		sbsec->flags |= SE_SBLABELSUPP;
 
+	/* Special handling for f2fs */
+	if (strncmp(sb->s_type->name, "f2fs", sizeof("f2fs")) == 0)
+		sbsec->flags |= SE_SBLABELSUPP;
+
 	/* Initialize the root inode. */
 	rc = inode_doinit_with_dentry(root_inode, root);
 


### PR DESCRIPTION
Hardcode f2fs to SELinux's whitelist for supporting ROMs that doesn't has sepolicy taken care for f2fs

Signed-off-by: arter97 qkrwngud825@gmail.com
